### PR TITLE
feat(graphql): add dry-monads gem and refactor JWT token creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 /config/master.key
 
 spec/examples.txt
+ecdsa_key.pem

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby "3.3.0"
 gem "rails", "~> 7.1.3", ">= 7.1.3.2"
 
 gem "bcrypt"
+gem "dry-monads"
 gem "graphql"
 gem "jwt"
 gem "pg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,13 @@ GEM
       reline (>= 0.3.8)
     diff-lcs (1.5.1)
     drb (2.2.1)
+    dry-core (1.0.1)
+      concurrent-ruby (~> 1.0)
+      zeitwerk (~> 2.6)
+    dry-monads (1.6.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0, < 2)
+      zeitwerk (~> 2.6)
     erubi (1.12.0)
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
@@ -281,6 +288,7 @@ PLATFORMS
 DEPENDENCIES
   bcrypt
   debug
+  dry-monads
   factory_bot_rails
   faker
   graphiql-rails

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ install:
 .PHONY: bundle
 bundle:
 	docker compose run --rm app bundle install
+	docker compose run --rm app_test bundle install
 
 .PHONY: console
 console:

--- a/app/graphql/mutations/authentication/log_in.rb
+++ b/app/graphql/mutations/authentication/log_in.rb
@@ -19,9 +19,7 @@ module Mutations
       private
 
       def generate_token(user)
-        ecdsa_key = OpenSSL::PKey::EC.generate("prime256v1")
-        payload = {data: user.email}
-        JWT.encode(payload, ecdsa_key, "ES256")
+        ::Authentication::JwtToken::CreateService.call(user)
       end
     end
   end

--- a/app/services/authentication/jwt_token/create_service.rb
+++ b/app/services/authentication/jwt_token/create_service.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module Authentication
+  module JwtToken
+    class CreateService < DryService
+      attr_reader :user, :expiration
+
+      def initialize(user, expiration: 24.hours.from_now.to_i)
+        @user = user
+        @expiration = expiration
+      end
+
+      def call
+        pem_file = yield read_pem_file
+        ecdsa_key = yield initialize_ecdsa_key(pem_file)
+        payload = yield generate_payload(ecdsa_key)
+        yield generate_token(ecdsa_key, payload)
+      end
+
+      private
+
+      PEM_FILE_PATH = "ecdsa_key.pem"
+
+      def read_pem_file
+        Try[Errno::ENOENT] do
+          File.read(PEM_FILE_PATH)
+        end.to_result.or do |error|
+          Failure("PEM file reading failed: #{error.message}")
+        end
+      end
+
+      def initialize_ecdsa_key(pem_file)
+        Try[OpenSSL::PKey::ECError] do
+          OpenSSL::PKey::EC.new(pem_file)
+        end.to_result.or do |error|
+          Failure("ECDSA key initialization failed: #{error.message}")
+        end
+      end
+
+      def generate_payload(ecdsa_key)
+        Try do
+          {
+            user_id: user.id,
+            type: user.authenticatable_type,
+            exp: expiration
+          }
+        end.to_result.or do |error|
+          Failure("Payload generation failed: #{error.message}")
+        end
+      end
+
+      def generate_token(ecdsa_key, payload)
+        Try[JWT::EncodeError, Errno::ENOENT] do
+          JWT.encode(payload, ecdsa_key, "ES256")
+        end.to_result.or do |error|
+          Failure("Token generation failed: #{error.message}")
+        end
+      end
+    end
+  end
+end

--- a/app/services/dry_service.rb
+++ b/app/services/dry_service.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class DryService
+  include Dry::Monads[:result, :do, :maybe, :try]
+
+  class << self
+    # Instantiates and calls the service at once
+    def call(*, &)
+      new(*).call(&)
+    end
+
+    # Accepts both symbolized and stringified attributes
+    def new(*args)
+      hsh = args.pop.symbolize_keys if args.last.is_a?(Hash)
+      super(*args, **(hsh || {}))
+    end
+  end
+end

--- a/spec/services/authentication/jjwt_token/create_service_spec.rb
+++ b/spec/services/authentication/jjwt_token/create_service_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe Authentication::JwtToken::CreateService do
+  subject(:service) { described_class.call(user, expiration: expiration) }
+
+  let(:user) { create(:user) }
+  let(:expiration) { 24.hours.from_now.to_i }
+
+  describe "#call" do
+    context "when all steps succeed" do
+      before do
+        allow(File).to receive(:read).and_return("fake_pem_content")
+        allow(OpenSSL::PKey::EC).to receive(:new).and_return("fake_ecdsa_key")
+        allow(JWT).to receive(:encode).and_return("fake_jwt_token")
+      end
+
+      it "returns a Success monad with the JWT token" do
+        expect(service).to eq("fake_jwt_token")
+      end
+    end
+
+    context "when PEM file reading fails" do
+      before do
+        allow(File).to receive(:read).and_raise(Errno::ENOENT, "file not found")
+      end
+
+      it "returns a Failure monad with the error message" do
+        expect(service).to be_failure
+        expect(service.failure).to include("PEM file reading failed")
+      end
+    end
+
+    context "when ECDSA key initialization fails" do
+      before do
+        allow(File).to receive(:read).and_return("fake_pem_content")
+        allow(OpenSSL::PKey::EC).to receive(:new).and_raise(OpenSSL::PKey::ECError, "invalid key")
+      end
+
+      it "returns a Failure monad with the error message" do
+        expect(service).to be_failure
+        expect(service.failure).to include("ECDSA key initialization failed")
+      end
+    end
+
+    context "when payload generation fails" do
+      before do
+        allow(File).to receive(:read).and_return("fake_pem_content")
+        allow(OpenSSL::PKey::EC).to receive(:new).and_return("fake_ecdsa_key")
+        allow(user).to receive(:id).and_raise(StandardError, "unexpected error")
+      end
+
+      it "returns a Failure monad with the error message" do
+        expect(service).to be_failure
+        expect(service.failure).to include("Payload generation failed")
+      end
+    end
+
+    context "when token generation fails" do
+      before do
+        allow(File).to receive(:read).and_return("fake_pem_content")
+        allow(OpenSSL::PKey::EC).to receive(:new).and_return("fake_ecdsa_key")
+        allow(JWT).to receive(:encode).and_raise(JWT::EncodeError, "invalid token")
+      end
+
+      it "returns a Failure monad with the error message" do
+        expect(service).to be_failure
+        expect(service.failure).to include("Token generation failed")
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Include the dry-monads gem into the Gemfile for improved error handling and monadic structures.
- Implement DryService with monadic helpers to be used by service classes.
- Create Authentication::JwtToken::CreateService to encapsulate JWT token creation logic previously in the log_in mutation.
- Update the log_in mutation to use the new JwtToken::CreateService.
- Add ecdsa_key.pem to .gitignore to prevent private key leaks.