### PR TITLE
feat(graphql): Create GymTrackrContext

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -11,7 +11,7 @@ class GraphqlController < ApplicationController
     query = params[:query]
     operation_name = params[:operationName]
     context = {
-      current_user: current_user
+      token: token
     }
     result = GymTrackrSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result
@@ -49,15 +49,13 @@ class GraphqlController < ApplicationController
     render json: {errors: [{message: e.message, backtrace: e.backtrace}], data: {}}, status: 500
   end
 
-  def current_user
+  def token
     return if request.headers["Authorization"].blank?
 
     bearer_token = request.headers["Authorization"].match("Bearer (.*)$")[1]
 
     if bearer_token
-      payload = ::Authentication::JwtToken::DecoderService.call(bearer_token)
-
-      User.find(payload["user_id"])
+      ::Authentication::JwtToken::DecoderService.call(bearer_token)
     end
   end
 end

--- a/app/graphql/gym_trackr_context.rb
+++ b/app/graphql/gym_trackr_context.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class GymTrackrContext < GraphQL::Query::Context
+  def token
+    token = fetch(:token, nil)
+
+    raise Errors::LogInError.new(token.failure) if token.failure?
+
+    token.success
+  end
+
+  def current_user_id
+    token["user_id"]
+  end
+
+  def current_user
+    return unless current_user_id
+
+    @current_user ||= User.find(current_user_id)
+  end
+end

--- a/app/graphql/gym_trackr_schema.rb
+++ b/app/graphql/gym_trackr_schema.rb
@@ -3,6 +3,7 @@
 class GymTrackrSchema < GraphQL::Schema
   mutation(Types::MutationType)
   query(Types::QueryType)
+  context_class GymTrackrContext
 
   # For batch-loading (see https://graphql-ruby.org/dataloader/overview.html)
   use GraphQL::Dataloader
@@ -14,6 +15,10 @@ class GymTrackrSchema < GraphQL::Schema
     #   return nil
     # end
     super
+  end
+
+  rescue_from(JWT::ExpiredSignature) do |err, obj, args, ctx, field|
+    raise GraphQL::ExecutionError, "Your token has expired. Please log in again."
   end
 
   # Union and Interface Resolution

--- a/app/graphql/mutations/authentication/log_in.rb
+++ b/app/graphql/mutations/authentication/log_in.rb
@@ -13,13 +13,16 @@ module Mutations
         raise Errors::LogInError.new("Incorrect email or password") unless user&.authenticate(password)
 
         token = generate_token(user)
-        {token: token, user: user}
+
+        raise Errors::LogInError.new(token.failure) if token.failure?
+
+        {token: token.success, user: user}
       end
 
       private
 
       def generate_token(user)
-        ::Authentication::JwtToken::CreateService.call(user)
+        ::Authentication::JwtToken::CreateService.call(user, expiration: 1.day.from_now.to_i)
       end
     end
   end

--- a/app/services/authentication/jwt_token/create_service.rb
+++ b/app/services/authentication/jwt_token/create_service.rb
@@ -14,7 +14,7 @@ module Authentication
         pem_file = yield read_pem_file
         ecdsa_key = yield initialize_ecdsa_key(pem_file)
         payload = yield generate_payload(ecdsa_key)
-        yield generate_token(ecdsa_key, payload)
+        generate_token(ecdsa_key, payload)
       end
 
       private

--- a/app/services/authentication/jwt_token/decoder_service.rb
+++ b/app/services/authentication/jwt_token/decoder_service.rb
@@ -12,7 +12,7 @@ module Authentication
       def call
         pem_file = yield read_pem_file
         ecdsa_key = yield initialize_ecdsa_key(pem_file)
-        yield decode_token(ecdsa_key)
+        decode_token(ecdsa_key)
       end
 
       private

--- a/spec/requests/graphql/mutations/users/log_in_spec.rb
+++ b/spec/requests/graphql/mutations/users/log_in_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require "rails_helper"
 
 RSpec.describe "GraphQL, logIn mutation", type: :request do
   subject(:execute_log_in_mutation) do
@@ -17,6 +17,7 @@ RSpec.describe "GraphQL, logIn mutation", type: :request do
     context "when the login is successfully" do
       before do
         create(:user, :coach, email: email, password: password)
+        allow(Authentication::JwtToken::CreateService).to receive(:call).and_return(Dry::Monads::Result::Success.new("token"))
         execute_log_in_mutation
       end
 

--- a/spec/services/authentication/jjwt_token/create_service_spec.rb
+++ b/spec/services/authentication/jjwt_token/create_service_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Authentication::JwtToken::CreateService do
       end
 
       it "returns the JWT token" do
-        expect(service).to eq("fake_jwt_token")
+        expect(service.success).to eq("fake_jwt_token")
       end
     end
 

--- a/spec/services/authentication/jjwt_token/decoder_service_spec.rb
+++ b/spec/services/authentication/jjwt_token/decoder_service_spec.rb
@@ -11,11 +11,14 @@ RSpec.describe Authentication::JwtToken::DecoderService do
       before do
         allow(File).to receive(:read).and_return("fake_pem_content")
         allow(OpenSSL::PKey::EC).to receive(:new).and_return("fake_ecdsa_key")
-        allow(JWT).to receive(:decode).with(any_args).and_return([{"user_id" => user.id, "type" => user.authenticatable_type, "exp" => 1000}])
+        allow(JWT)
+          .to receive(:decode)
+          .with(any_args)
+          .and_return([{"user_id" => user.id, "type" => user.authenticatable_type, "exp" => 1000}])
       end
 
       it "returns the decoded payload" do
-        expect(service)
+        expect(service.success)
           .to a_hash_including("user_id" => user.id, "type" => user.authenticatable_type, "exp" => 1000)
       end
     end


### PR DESCRIPTION
- Update context hash in GraphqlController to use current_user_id
- Define current_user_id method in GraphqlController to decode JWT token and fetch the user ID
- Add current_user and current_user_id in new GymTrackrContext
- Set GymTrackrSchema's context_class to use GymTrackrContext
- Add JWT::ExpiredSignature rescue in GymTrackrSchema
- Update token generation to include expiration date in log_in mutation