### PR TITLE
refactor(graphql): update JWT handling

### DIFF
--- a/app/graphql/errors/authentication_error.rb
+++ b/app/graphql/errors/authentication_error.rb
@@ -1,0 +1,7 @@
+module Errors
+  class AuthenticationError < GraphQL::ExecutionError
+    def initialize(message)
+      super("Authentication error: #{message}")
+    end
+  end
+end

--- a/app/graphql/gym_trackr_context.rb
+++ b/app/graphql/gym_trackr_context.rb
@@ -4,13 +4,19 @@ class GymTrackrContext < GraphQL::Query::Context
   def token
     token = fetch(:token, nil)
 
-    raise Errors::LogInError.new(token.failure) if token.failure?
+    raise Errors::AuthenticationError, token.failure if token.failure?
 
     token.success
   end
 
+  def current_user?
+    return false unless token
+
+    true
+  end
+
   def current_user_id
-    token["user_id"]
+    token.fetch("user_id", nil)
   end
 
   def current_user

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -6,5 +6,9 @@ module Mutations
     field_class Types::BaseField
     input_object_class Types::BaseInputObject
     object_class Types::BaseObject
+
+    def authenticated_user?
+      context.current_user?
+    end
   end
 end

--- a/app/services/authentication/jwt_token/create_service.rb
+++ b/app/services/authentication/jwt_token/create_service.rb
@@ -25,7 +25,7 @@ module Authentication
         Try[Errno::ENOENT] do
           File.read(PEM_FILE_PATH)
         end.to_result.or do |error|
-          Failure("PEM file reading failed: #{error.message}")
+          Failure("PEM file - #{error.message}")
         end
       end
 
@@ -33,7 +33,7 @@ module Authentication
         Try[OpenSSL::PKey::ECError] do
           OpenSSL::PKey::EC.new(pem_file)
         end.to_result.or do |error|
-          Failure("ECDSA key initialization failed: #{error.message}")
+          Failure("ECDSA key - #{error.message}")
         end
       end
 

--- a/app/services/authentication/jwt_token/decoder_service.rb
+++ b/app/services/authentication/jwt_token/decoder_service.rb
@@ -23,7 +23,7 @@ module Authentication
         Try[Errno::ENOENT] do
           File.read(PEM_FILE_PATH)
         end.to_result.or do |error|
-          Failure("PEM file reading failed: #{error.message}")
+          Failure("PEM file - #{error.message}")
         end
       end
 
@@ -31,7 +31,7 @@ module Authentication
         Try[OpenSSL::PKey::ECError] do
           OpenSSL::PKey::EC.new(pem_file)
         end.to_result.or do |error|
-          Failure("ECDSA key initialization failed: #{error.message}")
+          Failure("ECDSA key - #{error.message}")
         end
       end
 
@@ -39,7 +39,7 @@ module Authentication
         Try[JWT::DecodeError, JWT::ExpiredSignature] do
           JWT.decode(bearer_token, ecdsa_key, true, algorithm: "ES256")[0]
         end.to_result.or do |error|
-          Failure("Token decoding failed: #{error.message}")
+          Failure("JWT - #{error.message}")
         end
       end
     end

--- a/spec/services/authentication/jjwt_token/create_service_spec.rb
+++ b/spec/services/authentication/jjwt_token/create_service_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Authentication::JwtToken::CreateService do
 
       it "returns a Failure monad with the error message" do
         expect(service).to be_failure
-        expect(service.failure).to include("PEM file reading failed")
+        expect(service.failure).to include("PEM file - No such file or directory - file not found")
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe Authentication::JwtToken::CreateService do
 
       it "returns a Failure monad with the error message" do
         expect(service).to be_failure
-        expect(service.failure).to include("ECDSA key initialization failed")
+        expect(service.failure).to include("ECDSA key - invalid key")
       end
     end
 

--- a/spec/services/authentication/jjwt_token/decoder_service_spec.rb
+++ b/spec/services/authentication/jjwt_token/decoder_service_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe Authentication::JwtToken::DecoderService do
 
     context "when PEM file reading fails" do
       before do
-        allow(File).to receive(:read).and_raise(Errno::ENOENT, "file not found")
+        allow(File).to receive(:read).and_raise(Errno::ENOENT)
       end
 
       it "returns a Failure monad with the error message" do
         expect(service).to be_failure
-        expect(service.failure).to include("PEM file reading failed")
+        expect(service.failure).to include("PEM file - No such file or directory")
       end
     end
 
@@ -42,7 +42,7 @@ RSpec.describe Authentication::JwtToken::DecoderService do
 
       it "returns a Failure monad with the error message" do
         expect(service).to be_failure
-        expect(service.failure).to include("ECDSA key initialization failed")
+        expect(service.failure).to include("ECDSA key - invalid key")
       end
     end
 
@@ -55,7 +55,7 @@ RSpec.describe Authentication::JwtToken::DecoderService do
 
       it "returns a Failure monad with the error message" do
         expect(service).to be_failure
-        expect(service.failure).to include("Token decoding failed")
+        expect(service.failure).to include("JWT - invalid token")
       end
     end
   end


### PR DESCRIPTION
- Integrate Dry::Monads result pattern for JWT token processing in graphql_controller.rb
- Add new GraphQL::ExecutionError subclass to handle authentication errors
- Flattened context in graphql_controller.rb to directly pass the token
- Update JWT token creation and decoding services to use more concise failure messages
- Implement GymTrackrContext for better token and user management in GraphQL context
- Extend GymTrackrSchema to handle JWT expired signature exceptions globally
- Refactor log_in mutation to handle token creation failures
- Add authenticated_user? check in base_mutation.rb
- Update tests to align with the refactored services and controller methods
- Adjust specs to use rails_helper instead of spec_helper