### PR TITLE
feat(graphql): implement referral token generation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "pg"
 gem "puma", ">= 5.0"
 gem "propshaft"
 gem "tzinfo-data", platforms: %i[windows jruby]
+gem "ruby-ulid", "~> 0.8.0"
 
 group :development do
   gem "graphiql-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,6 +253,7 @@ GEM
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)
     ruby-progressbar (1.13.0)
+    ruby-ulid (0.8.0)
     standard (1.35.1)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -300,6 +301,7 @@ DEPENDENCIES
   rails (~> 7.1.3, >= 7.1.3.2)
   rspec
   rspec-rails
+  ruby-ulid (~> 0.8.0)
   standard
   tzinfo-data
 

--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,17 @@
 .PHONY: install
 install:
+	docker compose build app app-test --no-cache && \
 	docker compose run --rm app bash -c "\
 	bundle install && \
-	bundle exec rails db:drop && \
-	bundle exec rails db:create && \
-	bundle exec rails db:migrate && \
-	bundle exec rails db:seed"
-	docker compose run --rm app_test bash -c "\
+	bundle exec rails db:drop db:create db:migrate db:seed"
+	docker compose run --rm app-test bash -c "\
 	bundle install && \
-	bundle exec rails db:drop && \
-	bundle exec rails db:create && \
-	bundle exec rails db:migrate"
+	bundle exec rails db:drop db:create db:migrate db:seed"
 
 .PHONY: bundle
 bundle:
 	docker compose run --rm app bundle install
-	docker compose run --rm app_test bundle install
+	docker compose run --rm app-test bundle install
 
 .PHONY: console
 console:
@@ -28,15 +24,18 @@ server:
 .PHONY: db.migrate
 db.migrate:
 	docker compose run --rm app bundle exec rails db:migrate
+	docker compose run --rm app-test bundle exec rails db:migrate
 
 STEP ?= 1
 .PHONY: db.rollback
 db.rollback:
 	docker compose run --rm app bundle exec rails db:rollback STEP=$(STEP)
+	docker compose run --rm app-test bundle exec rails db:rollback STEP=$(STEP)
 
 .PHONY: db.reset
 db.reset:
 	docker compose run --rm app bundle exec rails db:reset
+	docker compose run --rm app-test bundle exec rails db:reset
 
 .PHONY: db.seed
 db.seed:
@@ -56,9 +55,9 @@ bash:
 
 .PHONY: test
 test:
-	docker compose run --rm app_test bundle exec rspec
+	docker compose run --rm app-test bundle exec rspec
 
 .PHONY: test.session
 test.session:
-	docker compose run --rm app_test bash
+	docker compose run --rm app-test bash
 

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -54,6 +54,6 @@ class GraphqlController < ApplicationController
     return Failure("JWT not present") if request.authorization.blank?
 
     bearer_token = request.authorization.match("Bearer (.*)$").to_a.second
-    ::Authentication::JwtToken::DecoderService.call(bearer_token)
+    Authentication::JwtToken::DecoderService.call(bearer_token)
   end
 end

--- a/app/graphql/errors/jwt_token_error.rb
+++ b/app/graphql/errors/jwt_token_error.rb
@@ -1,0 +1,7 @@
+module Errors
+  class JwtTokenError < GraphQL::ExecutionError
+    def initialize(message)
+      super("JWT - #{message}")
+    end
+  end
+end

--- a/app/graphql/gym_trackr_context.rb
+++ b/app/graphql/gym_trackr_context.rb
@@ -2,17 +2,19 @@
 
 class GymTrackrContext < GraphQL::Query::Context
   def token
-    token = fetch(:token, nil)
+    token = fetch(:token)
 
     raise Errors::AuthenticationError, token.failure if token.failure?
 
     token.success
   end
 
-  def current_user?
-    return false unless token
+  def authenticate_user!
+    raise Errors::AuthenticationError, "You need to authenticate to perform this action" unless authenticated?
+  end
 
-    true
+  def authenticated?
+    token && token.fetch("valid_for", nil) == "authentication"
   end
 
   def current_user_id

--- a/app/graphql/mutations/base_mutation.rb
+++ b/app/graphql/mutations/base_mutation.rb
@@ -6,9 +6,5 @@ module Mutations
     field_class Types::BaseField
     input_object_class Types::BaseInputObject
     object_class Types::BaseObject
-
-    def authenticated_user?
-      context.current_user?
-    end
   end
 end

--- a/app/graphql/mutations/referral/generate_jwt.rb
+++ b/app/graphql/mutations/referral/generate_jwt.rb
@@ -1,0 +1,25 @@
+module Mutations
+  module Referral
+    class GenerateJwt < BaseMutation
+      argument :expiration, Integer, required: false
+
+      field :referal_token, String, null: true
+
+      def resolve(expiration: nil)
+        context.authenticate_user!
+
+        token = generate_token(context.current_user, expiration: expiration)
+
+        raise Errors::JwtTokenError, token.failure if token.failure?
+
+        {referal_token: token.success}
+      end
+
+      private
+
+      def generate_token(user, expiration:)
+        ::Referrals::JwtToken::CreateService.call(user, expiration: expiration)
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -4,5 +4,6 @@ module Types
   class MutationType < Types::BaseObject
     field :signup, mutation: Mutations::Authentication::SignUp
     field :login, mutation: Mutations::Authentication::LogIn
+    field :generate_referal_token, mutation: Mutations::Referral::GenerateJwt
   end
 end

--- a/app/models/referral_token.rb
+++ b/app/models/referral_token.rb
@@ -1,0 +1,3 @@
+class ReferralToken < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ApplicationRecord
   has_secure_password
 
   belongs_to :authenticatable, polymorphic: true
+  has_many :referral_tokens
 
   validates :email, presence: true, uniqueness: true
   validates :password, presence: true, length: {minimum: 6}

--- a/app/services/authentication/jwt_token/decoder_service.rb
+++ b/app/services/authentication/jwt_token/decoder_service.rb
@@ -10,26 +10,16 @@ module Authentication
       end
 
       def call
-        pem_file = yield read_pem_file
-        ecdsa_key = yield initialize_ecdsa_key(pem_file)
+        ecdsa_key = yield initialize_ecdsa_key
         decode_token(ecdsa_key)
       end
 
       private
 
-      PEM_FILE_PATH = "ecdsa_key.pem"
-
-      def read_pem_file
-        Try[Errno::ENOENT] do
-          File.read(PEM_FILE_PATH)
-        end.to_result.or do |error|
-          Failure("PEM file - #{error.message}")
-        end
-      end
-
-      def initialize_ecdsa_key(pem_file)
+      def initialize_ecdsa_key
         Try[OpenSSL::PKey::ECError] do
-          OpenSSL::PKey::EC.new(pem_file)
+          ec_key = ENV["ECDSA_KEY"]
+          OpenSSL::PKey::EC.new(ec_key)
         end.to_result.or do |error|
           Failure("ECDSA key - #{error.message}")
         end

--- a/db/migrate/20240512210309_create_referral_tokens.rb
+++ b/db/migrate/20240512210309_create_referral_tokens.rb
@@ -1,0 +1,10 @@
+class CreateReferralTokens < ActiveRecord::Migration[7.1]
+  def change
+    create_table :referral_tokens, id: false do |t|
+      t.string :id, null: false, primary_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_11_105118) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_12_210309) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -32,6 +32,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_11_105118) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "referral_tokens", id: :string, force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_referral_tokens_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.string "password_digest", null: false
@@ -43,4 +50,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_11_105118) do
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
+  add_foreign_key "referral_tokens", "users"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     environment:
       RAILS_ENV: development
       DATABASE_URL: postgres://postgres:password@db:5432/gym_trackr_development
+      ECDSA_KEY: ${ECDSA_KEY}
     networks:
       - gym_trackr_network
 
@@ -41,14 +42,14 @@ services:
     ports:
       - "5432:5432"
 
-  app_test:
+  app-test:
     build:
       context: .
       dockerfile: Dockerfile
     image: gym_tracker-test
     init: true
     depends_on:
-      db_test:
+      db-test:
         condition: service_healthy
     tty: true
     stdin_open: true
@@ -60,11 +61,12 @@ services:
       - "3001:3000"
     environment:
       RAILS_ENV: test
-      DATABASE_URL: postgres://postgres:password@db:5432/gym_trackr_test
+      DATABASE_URL: postgres://postgres:password@db-test:5432/gym_trackr_test
+      ECDSA_KEY: ${ECDSA_KEY}
     networks:
       - gym_trackr_network
 
-  db_test:
+  db-test:
     image: postgres:latest
     volumes:
       - postgres_data_test:/var/lib/postgresql/data
@@ -72,8 +74,6 @@ services:
       POSTGRES_DB: gym_trackr_test
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
-    networks:
-      - gym_trackr_network
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
@@ -81,6 +81,8 @@ services:
       retries: 3
     ports:
       - "5433:5432"
+    networks:
+      - gym_trackr_network
 
   pgadmin:
     image: dpage/pgadmin4

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,3 @@
-# This file is copied to spec/ when you run 'rails generate rspec:install'
-require "spec_helper"
-
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 # Prevent database truncation if the environment is production

--- a/spec/requests/graphql/mutations/users/log_in_spec.rb
+++ b/spec/requests/graphql/mutations/users/log_in_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require "spec_helper"
 
 RSpec.describe "GraphQL, logIn mutation", type: :request do
   subject(:execute_log_in_mutation) do

--- a/spec/services/authentication/jjwt_token/create_service_spec.rb
+++ b/spec/services/authentication/jjwt_token/create_service_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require "spec_helper"
 
 RSpec.describe Authentication::JwtToken::CreateService do
   subject(:service) { described_class.call(user, expiration: expiration) }
@@ -9,7 +9,6 @@ RSpec.describe Authentication::JwtToken::CreateService do
   describe "#call" do
     context "when all steps succeed" do
       before do
-        allow(File).to receive(:read).and_return("fake_pem_content")
         allow(OpenSSL::PKey::EC).to receive(:new).and_return("fake_ecdsa_key")
         allow(JWT).to receive(:encode).and_return("fake_jwt_token")
       end
@@ -19,20 +18,8 @@ RSpec.describe Authentication::JwtToken::CreateService do
       end
     end
 
-    context "when PEM file reading fails" do
-      before do
-        allow(File).to receive(:read).and_raise(Errno::ENOENT, "file not found")
-      end
-
-      it "returns a Failure monad with the error message" do
-        expect(service).to be_failure
-        expect(service.failure).to include("PEM file - No such file or directory - file not found")
-      end
-    end
-
     context "when ECDSA key initialization fails" do
       before do
-        allow(File).to receive(:read).and_return("fake_pem_content")
         allow(OpenSSL::PKey::EC).to receive(:new).and_raise(OpenSSL::PKey::ECError, "invalid key")
       end
 
@@ -44,7 +31,6 @@ RSpec.describe Authentication::JwtToken::CreateService do
 
     context "when payload generation fails" do
       before do
-        allow(File).to receive(:read).and_return("fake_pem_content")
         allow(OpenSSL::PKey::EC).to receive(:new).and_return("fake_ecdsa_key")
         allow(user).to receive(:id).and_raise(StandardError, "unexpected error")
       end
@@ -57,7 +43,6 @@ RSpec.describe Authentication::JwtToken::CreateService do
 
     context "when token generation fails" do
       before do
-        allow(File).to receive(:read).and_return("fake_pem_content")
         allow(OpenSSL::PKey::EC).to receive(:new).and_return("fake_ecdsa_key")
         allow(JWT).to receive(:encode).and_raise(JWT::EncodeError, "invalid token")
       end

--- a/spec/services/referrals/jwt_token/create_service_spec.rb
+++ b/spec/services/referrals/jwt_token/create_service_spec.rb
@@ -1,0 +1,70 @@
+require "spec_helper"
+
+RSpec.describe Referrals::JwtToken::CreateService do
+  subject(:result) { service.call }
+
+  describe "#call" do
+    let(:user) { create(:user, authenticatable_type: "Coach") }
+    let(:service) { described_class.new(user) }
+
+    context "when the user is a coach" do
+      before do
+        allow(ENV).to receive(:[]).with("ECDSA_KEY").and_return("your_ecdsa_private_key")
+        allow(OpenSSL::PKey::EC).to receive(:new).and_return("fake_ecdsa_key")
+        allow(JWT).to receive(:encode).and_return("mock_jwt_token")
+      end
+
+      it "successfully creates a referral JWT token" do
+        expect(result).to be_success
+        expect(result.value!).to eq("mock_jwt_token")
+        expect(ReferralToken.where(user_id: user.id).count).to eq(1)
+      end
+    end
+
+    context "when the user is not a coach" do
+      let(:user) { build(:user, authenticatable_type: "Client") }
+
+      it "fails to create a referral JWT token" do
+        expect(result).to be_failure
+        expect(result.failure).to eq("You are not able to perform this action")
+      end
+    end
+
+    context "when the ECDSA key is invalid" do
+      before do
+        allow(ENV).to receive(:[]).with("ECDSA_KEY").and_return("invalid_ecdsa_key")
+      end
+
+      it "handles ECDSA key errors" do
+        expect(result).to be_failure
+        expect(result.failure).to include("ECDSA key -")
+      end
+    end
+
+    context "when token generation fails" do
+      before do
+        allow(OpenSSL::PKey::EC).to receive(:new).and_return("fake_ecdsa_key")
+        allow(JWT).to receive(:encode).and_raise(JWT::EncodeError, "invalid token")
+      end
+
+      it "handles JWT encoding errors" do
+        expect(result).to be_failure
+        expect(result.failure).to include("Token generation failed:")
+      end
+    end
+
+    context "when creating the ReferralToken record fails" do
+      before do
+        allow(ENV).to receive(:[]).with("ECDSA_KEY").and_return("your_ecdsa_private_key")
+        allow(OpenSSL::PKey::EC).to receive(:new).and_return("fake_ecdsa_key")
+        allow(JWT).to receive(:encode).and_return("mock_jwt_token")
+        allow(ReferralToken).to receive(:create!).and_raise(ActiveRecord::RecordInvalid)
+      end
+
+      it "handles ActiveRecord errors during token creation" do
+        expect(result).to be_failure
+        expect(result.failure).to include("Token generation failed:")
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Add gem 'ruby-ulid' for generating ULIDs.
- Include migration for creating referral_tokens table to store referral tokens.
- Introduce new GraphQL mutation Mutations::Referal::GenerateJwt for creating referral tokens.
- Update User model to include has_many association with referral_tokens.
- Add Models::ReferalToken and Errors::JwtTokenError.
- Modify Authentication::JwtToken::CreateService to freeze constants and include a new TOKEN_PURPOSE to specify JWT is for authentication.
- Create Referrals::JwtToken::CreateService to handle referral token creation with error handling for user validation and PEM reading.
- Modify GymTrackrContext to include a new method #authenticate_user! and update #authenticated? method with additional checks.
- Remove unnecessary :: from a method call in GraphqlController.
- Adjust Makefile to apply db migrations to the test environment.
- Remove redundant `authenticated_user?` method from the base mutation.
- Update Gemfile.lock with the newly added gem's lock.